### PR TITLE
DM-28730: Turn off setSpectra initialization by default

### DIFF
--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -342,7 +342,7 @@ class ScarletDeblendConfig(pexConfig.Config):
              "- 'fit: use a PSF fitting model to determine the number of components (not yet implemented)")
     )
     setSpectra = pexConfig.Field(
-        dtype=bool, default=True,
+        dtype=bool, default=False,
         doc="Whether or not to solve for the best-fit spectra during initialization. "
             "This makes initialization slightly longer, as it requires a convolution "
             "to set the optimal spectra, but results in a much better initial log-likelihood "


### PR DESCRIPTION
For large skinny blends the `setSpectra` method of initialization
causes the initialization to run out of memory, so by default we
turn this option off. DM-28870 will investigate if there is a
criteria (such as peaks*bands*area) that we can use to determine
when it is safe to use setSpectra and when to skip that step.