### PR TITLE
DM-27929: refactor meas_extensions_scarlet and skip sky objects

### DIFF
--- a/tests/test_deblend.py
+++ b/tests/test_deblend.py
@@ -86,7 +86,8 @@ class TestDeblend(lsst.utils.tests.TestCase):
 
         # Add a footprint that is too large
         src = catalog.addNew()
-        ss = SpanSet.fromShape(20, Stencil.BOX, offset=(50, 50))
+        halfLength = int(np.ceil(np.sqrt(config.maxFootprintArea) + 1))
+        ss = SpanSet.fromShape(halfLength, Stencil.BOX, offset=(50, 50))
         bigfoot = Footprint(ss)
         bigfoot.addPeak(50, 50, 100)
         src.setFootprint(bigfoot)
@@ -95,7 +96,7 @@ class TestDeblend(lsst.utils.tests.TestCase):
         src = catalog.addNew()
         ss = SpanSet.fromShape(10, Stencil.BOX, offset=(75, 20))
         denseFoot = Footprint(ss)
-        for n in range(5):
+        for n in range(config.maxNumberOfPeaks+1):
             denseFoot.addPeak(70+2*n, 15+2*n, 10*n)
         src.setFootprint(denseFoot)
 

--- a/tests/test_deblend.py
+++ b/tests/test_deblend.py
@@ -23,12 +23,15 @@ import unittest
 
 import numpy as np
 
+from lsst.geom import Point2I
 import lsst.utils.tests
 import lsst.afw.image as afwImage
 from lsst.meas.algorithms import SourceDetectionTask
 from lsst.meas.extensions.scarlet import ScarletDeblendTask
 from lsst.afw.table import SourceCatalog
-
+from lsst.afw.detection import Footprint
+from lsst.afw.detection.multiband import heavyFootprintToImage
+from lsst.afw.geom import SpanSet, Stencil
 
 from utils import initData
 
@@ -37,12 +40,19 @@ class TestDeblend(lsst.utils.tests.TestCase):
     def test_deblend_task(self):
         # Set the random seed so that the noise field is unaffected
         np.random.seed(0)
-        # Test that executing the deblend task works
-        # In the future we can have more detailed tests,
-        # but for now this at least ensures that the task isn't broken
-        shape = (5, 31, 55)
-        coords = [(15, 25), (10, 30), (17, 38)]
-        amplitudes = [80, 60, 90]
+        shape = (5, 100, 115)
+        coords = [
+            # blend
+            (15, 25), (10, 30), (17, 38),
+            # isolated source
+            (85, 90),
+        ]
+        amplitudes = [
+            # blend
+            80, 60, 90,
+            # isolated source
+            20,
+        ]
         result = initData(shape, coords, amplitudes)
         targetPsfImage, psfImages, images, channels, seds, morphs, targetPsf, psfs = result
         B, Ny, Nx = shape
@@ -62,15 +72,108 @@ class TestDeblend(lsst.utils.tests.TestCase):
         schema = SourceCatalog.Table.makeMinimalSchema()
 
         detectionTask = SourceDetectionTask(schema=schema)
+
+        # Adjust config options to test skipping parents
         config = ScarletDeblendTask.ConfigClass()
-        config.maxIter = 300
+        config.maxIter = 100
+        config.maxFootprintArea = 1000
+        config.maxNumberOfPeaks = 4
         deblendTask = ScarletDeblendTask(schema=schema, config=config)
 
         table = SourceCatalog.Table.make(schema)
         detectionResult = detectionTask.run(table, coadds["r"])
         catalog = detectionResult.sources
-        self.assertEqual(len(catalog), 1)
+
+        # Add a footprint that is too large
+        src = catalog.addNew()
+        ss = SpanSet.fromShape(20, Stencil.BOX, offset=(50, 50))
+        bigfoot = Footprint(ss)
+        bigfoot.addPeak(50, 50, 100)
+        src.setFootprint(bigfoot)
+
+        # Add a footprint with too many peaks
+        src = catalog.addNew()
+        ss = SpanSet.fromShape(10, Stencil.BOX, offset=(75, 20))
+        denseFoot = Footprint(ss)
+        for n in range(5):
+            denseFoot.addPeak(70+2*n, 15+2*n, 10*n)
+        src.setFootprint(denseFoot)
+
+        # Run the deblender
         result = deblendTask.run(coadds, catalog)
+
+        # Make sure that the catalogs have the same sources in all bands,
+        # and check that band-independent columns are equal
+        bandIndependentColumns = [
+            "id",
+            "parent",
+            "deblend_nPeaks",
+            "deblend_nChild",
+            "deblend_peak_center_x",
+            "deblend_peak_center_y",
+            "deblend_runtime",
+            "deblend_iterations",
+            "deblend_logL",
+            "deblend_spectrumInitFlag",
+            "deblend_blendConvergenceFailedFlag",
+        ]
+        self.assertEqual(len(filters), len(result))
+        ref = result[filters[0]]
+        for f in filters[1:]:
+            for col in bandIndependentColumns:
+                np.testing.assert_array_equal(result[f][col], ref[col])
+
+        # Check that other columns are consistent
+        for f, _catalog in result.items():
+            parents = _catalog[_catalog["parent"] == 0]
+            # Check that the number of deblended children is consistent
+            self.assertEqual(np.sum(_catalog["deblend_nChild"]), len(_catalog)-len(parents))
+
+            for parent in parents:
+                children = _catalog[_catalog["parent"] == parent.get("id")]
+                # Check that nChild is set correctly
+                self.assertEqual(len(children), parent.get("deblend_nChild"))
+                # Check that parent columns are propagated to their children
+                for parentCol, childCol in config.columnInheritance.items():
+                    np.testing.assert_array_equal(parent.get(parentCol), children[childCol])
+
+            children = _catalog[_catalog["parent"] != 0]
+            for child in children:
+                fp = child.getFootprint()
+                img = heavyFootprintToImage(fp)
+                # Check that the flux at the center is correct.
+                # Note: this only works in this test image because the
+                # detected peak is in the same location as the scarlet peak.
+                # If the peak is shifted, the flux value will be correct
+                # but deblend_peak_center is not the correct location.
+                px = child.get("deblend_peak_center_x")
+                py = child.get("deblend_peak_center_y")
+                flux = img.image[Point2I(px, py)]
+                self.assertEqual(flux, child.get("deblend_peak_instFlux"))
+
+                # Check that the peak positions match the catalog entry
+                peaks = fp.getPeaks()
+                self.assertEqual(px, peaks[0].getIx())
+                self.assertEqual(py, peaks[0].getIy())
+
+            # Check that all sources have the correct number of peaks
+            for src in _catalog:
+                fp = src.getFootprint()
+                self.assertEqual(len(fp.peaks), src.get("deblend_nPeaks"))
+
+            # Check that only the large foorprint was flagged as too big
+            largeFootprint = np.zeros(len(_catalog), dtype=bool)
+            largeFootprint[2] = True
+            np.testing.assert_array_equal(largeFootprint, _catalog["deblend_parentTooBig"])
+
+            # Check that only the dense foorprint was flagged as too dense
+            denseFootprint = np.zeros(len(_catalog), dtype=bool)
+            denseFootprint[3] = True
+            np.testing.assert_array_equal(denseFootprint, _catalog["deblend_tooManyPeaks"])
+
+            # Check that only the appropriate parents were skipped
+            skipped = largeFootprint | denseFootprint
+            np.testing.assert_array_equal(skipped, _catalog["deblend_skipped"])
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
While implementing the code to skip sky sources, the goal of DM-27929, I discovered that inconsistencies in the way that primary sources are handled lead to columns in primary sources not being updated correctly. It has also been quite a while since meas_extensions_scarlet was first created and it needed a face-lift anyway, so this PR refactors meas_extensions_scarlet to do all of the deblending in the input (mergedDet) catalog to make sure that all of the sources have their flags set appropriately, then the band-dependent columns and footprints are set in individual catalogs that are copied from the original.