### PR TITLE
tickets/DM-32079: Dilate child footprints using PSF footprint

### DIFF
--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -851,6 +851,9 @@ class ScarletDeblendTask(pipeBase.Task):
                 nextLogTime = currentTime + self.config.loggingInterval
                 self.log.verbose("Deblended %d parent sources out of %d", parentIndex + 1, nParents)
 
+            # Clear the cached values in scarlet to clear out memory
+            scarlet.cache.Cache._cache = {}
+
         # Make sure that the number of new sources matches the number of
         # entries in each of the band dependent columns.
         # This should never trigger and is just a sanity check.

--- a/python/lsst/meas/extensions/scarlet/source.py
+++ b/python/lsst/meas/extensions/scarlet/source.py
@@ -29,7 +29,6 @@ from lsst.afw.geom import SpanSet
 from lsst.afw.detection import Footprint, PeakCatalog
 from lsst.afw.detection.multiband import MultibandFootprint
 from lsst.afw.image import Mask, MultibandImage
-import lsst.log
 
 __all__ = ["modelToHeavy"]
 

--- a/python/lsst/meas/extensions/scarlet/source.py
+++ b/python/lsst/meas/extensions/scarlet/source.py
@@ -24,17 +24,12 @@ import logging
 import numpy as np
 from scarlet.bbox import Box
 
-<<<<<<< HEAD
-from lsst.geom import Point2I
-import lsst.afw.detection as afwDet
-=======
 from lsst.geom import Point2I, Box2I, Extent2I
 from lsst.afw.geom import SpanSet
 from lsst.afw.detection import Footprint, PeakCatalog
 from lsst.afw.detection.multiband import MultibandFootprint
 from lsst.afw.image import Mask, MultibandImage
 import lsst.log
->>>>>>> 2d40ab5 (Fix HeavyFootprints generated from scarlet models)
 
 __all__ = ["modelToHeavy"]
 

--- a/python/lsst/meas/extensions/scarlet/source.py
+++ b/python/lsst/meas/extensions/scarlet/source.py
@@ -29,7 +29,7 @@ from lsst.geom import Point2I
 import lsst.afw.detection as afwDet
 =======
 from lsst.geom import Point2I, Box2I, Extent2I
-from lsst.afw.geom import SpanSet, Stencil
+from lsst.afw.geom import SpanSet
 from lsst.afw.detection import Footprint, PeakCatalog
 from lsst.afw.detection.multiband import MultibandFootprint
 from lsst.afw.image import Mask, MultibandImage

--- a/python/lsst/meas/extensions/scarlet/source.py
+++ b/python/lsst/meas/extensions/scarlet/source.py
@@ -149,6 +149,6 @@ def modelToHeavy(source, mExposure, blend, xy0=Point2I(), dtype=np.float32):
     # Create the MultibandHeavyFootprint
     foot = Footprint(spans)
     foot.setPeakCatalog(peakCat)
-    model = MultibandImage(mExposure.filters, model, spans.getBBox())
+    model = MultibandImage(mExposure.filters, model, valid.getBBox())
     mHeavy = MultibandFootprint.fromImages(mExposure.filters, model, footprint=foot)
     return mHeavy

--- a/tests/test_scarlet.py
+++ b/tests/test_scarlet.py
@@ -24,8 +24,6 @@ import unittest
 import numpy as np
 import scarlet
 from scarlet.initialization import init_source
-
-import lsst.meas.extensions.scarlet as mes
 import lsst.utils.tests
 
 from utils import numpyToStack, initData
@@ -52,19 +50,6 @@ class TestLsstSource(lsst.utils.tests.TestCase):
         # Convolve the model with the observed PSF
         model = src.get_model(frame=src.frame)
         model = observation.render(model)
-
-        # Test Model to Heavy
-        filters = [f for f in "grizy"]
-        src.detectedPeak = peak
-        hFoot = mes.source.modelToHeavy(src, filters, bbox.getMin(), observation)
-
-        # Test the peak in each band
-        for single in hFoot:
-            peaks = single.getPeaks()
-            self.assertEqual(len(peaks), 1)
-            hPeak = peaks[0]
-            self.assertEqual(hPeak.getIx()-xmin, coords[0][1])
-            self.assertEqual(hPeak.getIy()-ymin, coords[0][0])
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Replace an incorrect thresholding algorithm with a more robust dilation algorithm to convolve scarlet models with the seeing in each band and properly truncate the resulting footprint.