### PR TITLE
DM-40451: Allow deblending to continue even when data is missing for some bands

### DIFF
--- a/python/lsst/meas/extensions/scarlet/io.py
+++ b/python/lsst/meas/extensions/scarlet/io.py
@@ -367,7 +367,7 @@ class ScarletModelData:
         }
         return cls(**dataShallowCopy)
 
-    def updateCatalogFootprints(self, catalog, band, psfModel, maskImage, redistributeImage=None,
+    def updateCatalogFootprints(self, catalog, band, psfModel, maskImage=None, redistributeImage=None,
                                 removeScarletData=True, updateFluxColumns=True):
         """Use the scarlet models to set HeavyFootprints for modeled sources
 
@@ -382,6 +382,8 @@ class ScarletModelData:
         maskImage : `lsst.afw.image.MaskX`
             The masked image used to calculate the fraction of pixels
             in each footprint with valid data.
+            This is only used when `updateFluxColumns` is `True`,
+            and is required if it is.
         redistributeImage : `lsst.afw.image.Image`
             The image that is the source for flux re-distribution.
             If `redistributeImage` is `None` then flux re-distribution is
@@ -489,6 +491,8 @@ def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, maskImage, red
     maskImage : `lsst.afw.image.MaskX`
         The masked image used to calculate the fraction of pixels
         in each footprint with valid data.
+        This is only used when `updateFluxColumns` is `True`,
+        and is required if it is.
     redistributeImage : `lsst.afw.image.Image`
         The image that is the source for flux re-distribution.
         If `redistributeImage` is `None` then flux re-distribution is
@@ -558,11 +562,12 @@ def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, maskImage, red
             useFlux=useFlux,
         )
         sourceRecord.setFootprint(heavy)
-        # Set the fraction of pixels with valid data.
-        coverage = calculateFootprintCoverage(heavy, maskImage)
-        sourceRecord.set("deblend_dataCoverage", coverage)
 
         if updateFluxColumns:
+            # Set the fraction of pixels with valid data.
+            coverage = calculateFootprintCoverage(heavy, maskImage)
+            sourceRecord.set("deblend_dataCoverage", coverage)
+
             # Set the flux of the scarlet model
             # TODO: this field should probably be deprecated,
             # since DM-33710 gives users access to the scarlet models.

--- a/python/lsst/meas/extensions/scarlet/io.py
+++ b/python/lsst/meas/extensions/scarlet/io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from typing import Any
 import logging
 import numpy as np
 from scarlet.bbox import Box, overlapped_slices
@@ -11,6 +10,7 @@ from scarlet.lite.measure import weight_sources
 
 from lsst.geom import Box2I, Extent2I, Point2I, Point2D
 from lsst.afw.image import computePsfImage
+from lsst.afw.detection import Footprint
 
 from .source import liteModelToHeavy
 
@@ -255,11 +255,16 @@ class ScarletBlendData:
     psfCenter : `tuple` of `int`
         The location used for the center of the PSF for
         the blend.
+    bands : `list` of `str`
+        The names of the bands.
+        The order of the bands must be the same as the order of
+        the multiband model arrays, and SEDs.
     """
     xy0: tuple[int, int]
     extent: tuple[int, int]
     sources: dict[int, ScarletSourceData]
     psfCenter: tuple[float, float]
+    bands: tuple[str]
 
     def asDict(self) -> dict:
         """Return the object encoded into a dict for JSON serialization
@@ -269,9 +274,13 @@ class ScarletBlendData:
         result : `dict`
             The object encoded as a JSON compatible dict
         """
-        result: dict[str, Any] = {"xy0": self.xy0, "extent": self.extent, "psfCenter": self.psfCenter}
-        result['sources'] = {id: source.asDict() for id, source in self.sources.items()}
-        return result
+        return {
+            "xy0": self.xy0,
+            "extent": self.extent,
+            "psfCenter": self.psfCenter,
+            "sources": {id: source.asDict() for id, source in self.sources.items()},
+            "bands": self.bands,
+        }
 
     @classmethod
     def fromDict(cls, data: dict) -> "ScarletBlendData":
@@ -294,21 +303,18 @@ class ScarletBlendData:
         dataShallowCopy["psfCenter"] = tuple(data["psfCenter"])
         dataShallowCopy["sources"] = {int(id): ScarletSourceData.fromDict(source)
                                       for id, source in data['sources'].items()}
+        dataShallowCopy["bands"] = tuple(data["bands"])
         return cls(**dataShallowCopy)
 
 
 class ScarletModelData:
     """A container that propagates scarlet models for an entire `SourceCatalog`
     """
-    def __init__(self, bands, psf, blends=None):
+    def __init__(self, psf, blends=None):
         """Initialize an instance
 
         Parameters
         ----------
-        bands : `list` of `str`
-            The names of the bands.
-            The order of the bands must be the same as the order of
-            the multiband model arrays, and SEDs.
         psf : `numpy.ndarray`
             The 2D array of the PSF in scarlet model space.
             This is typically a narrow Gaussian integrated over the
@@ -317,7 +323,6 @@ class ScarletModelData:
             Initial `dict` that maps parent IDs from the source catalog
             to the scarlet model data for the parent blend.
         """
-        self.bands = bands
         self.psf = psf
         if blends is None:
             blends = {}
@@ -332,7 +337,6 @@ class ScarletModelData:
             The result of the object converted into a JSON format
         """
         result = {
-            "bands": self.bands,
             "psfShape": self.psf.shape,
             "psf": list(self.psf.flatten()),
             "blends": {id: blend.asDict() for id, blend in self.blends.items()}
@@ -361,13 +365,9 @@ class ScarletModelData:
             int(id): ScarletBlendData.fromDict(blend)
             for id, blend in data['blends'].items()
         }
-        if "filters" in dataShallowCopy:
-            # Support the original version,
-            # which used "filters" instead of the now canonical "bands."
-            dataShallowCopy["bands"] = dataShallowCopy.pop("filters")
         return cls(**dataShallowCopy)
 
-    def updateCatalogFootprints(self, catalog, band, psfModel, redistributeImage=None,
+    def updateCatalogFootprints(self, catalog, band, psfModel, maskImage, redistributeImage=None,
                                 removeScarletData=True, updateFluxColumns=True):
         """Use the scarlet models to set HeavyFootprints for modeled sources
 
@@ -379,6 +379,9 @@ class ScarletModelData:
             The name of the band that the catalog data describes.
         psfModel : `lsst.afw.detection.Psf`
             The observed PSF model for the catalog.
+        maskImage : `lsst.afw.image.MaskX`
+            The masked image used to calculate the fraction of pixels
+            in each footprint with valid data.
         redistributeImage : `lsst.afw.image.Image`
             The image that is the source for flux re-distribution.
             If `redistributeImage` is `None` then flux re-distribution is
@@ -394,8 +397,6 @@ class ScarletModelData:
         # Iterate over the blends, since flux re-distribution must be done on
         # all of the children with the same parent
         parents = catalog[catalog["parent"] == 0]
-        # Get the index of the model for the given band
-        bandIndex = self.bands.index(band)
 
         for parentRecord in parents:
             parentId = parentRecord.getId()
@@ -406,11 +407,32 @@ class ScarletModelData:
                 # The parent was skipped in the deblender, so there are
                 # no models for its sources.
                 continue
+
+            if band not in blendModel.bands:
+                parent = catalog.find(parentId)
+                peaks = parent.getFootprint().peaks
+                # Set the footprint and coverage of the sources in this blend
+                # to zero
+                parentRecord["deblend_dataCoverage"] = 0
+                for sourceId, sourceData in blendModel.sources.items():
+                    sourceRecord = catalog.find(sourceId)
+                    footprint = Footprint()
+                    peakIdx = np.where(peaks["id"] == sourceData.peakId)[0][0]
+                    peak = peaks[peakIdx]
+                    footprint.addPeak(peak.getIx(), peak.getIy(), peak.getPeakValue())
+                    sourceRecord.setFootprint(footprint)
+                    sourceRecord["deblend_dataCoverage"] = 0
+                continue
+
+            # Get the index of the model for the given band
+            bandIndex = blendModel.bands.index(band)
+
             updateBlendRecords(
                 blendData=blendModel,
                 catalog=catalog,
                 modelPsf=self.psf,
                 observedPsf=psfModel,
+                maskImage=maskImage,
                 redistributeImage=redistributeImage,
                 bandIndex=bandIndex,
                 parentFootprint=parentRecord.getFootprint(),
@@ -422,7 +444,35 @@ class ScarletModelData:
                 del self.blends[parentId]
 
 
-def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, redistributeImage, bandIndex,
+def calculateFootprintCoverage(footprint, maskImage):
+    """Calculate the fraction of pixels with no data in a Footprint
+
+    Parameters
+    ----------
+    footprint : `lsst.afw.detection.Footprint`
+        The footprint to check for missing data.
+    maskImage : `lsst.afw.image.MaskX`
+        The mask image with the ``NO_DATA`` bit set.
+
+    Returns
+    -------
+    coverage : `float`
+        The fraction of pixels in `footprint` where the ``NO_DATA`` bit is set.
+    """
+    # Store the value of "NO_DATA" from the mask plane.
+    noDataInt = 2**maskImage.getMaskPlaneDict()["NO_DATA"]
+
+    # Calculate the coverage in the footprint
+    bbox = footprint.getBBox()
+    spans = footprint.spans.asArray()
+    totalArea = footprint.getArea()
+    mask = maskImage[bbox].array & noDataInt
+    noData = (mask * spans) > 0
+    coverage = 1 - np.sum(noData)/totalArea
+    return coverage
+
+
+def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, maskImage, redistributeImage, bandIndex,
                        parentFootprint, updateFluxColumns):
     """Create footprints and update band-dependent columns in the catalog
 
@@ -436,6 +486,9 @@ def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, redistributeIm
         The 2D model of the PSF.
     observedPsf : `lsst.afw.detection.Psf`
         The observed PSF model for the catalog.
+    maskImage : `lsst.afw.image.MaskX`
+        The masked image used to calculate the fraction of pixels
+        in each footprint with valid data.
     redistributeImage : `lsst.afw.image.Image`
         The image that is the source for flux re-distribution.
         If `redistributeImage` is `None` then flux re-distribution is
@@ -458,7 +511,6 @@ def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, redistributeIm
 
     blend = dataToScarlet(
         blendData=blendData,
-        nBands=1,
         bandIndex=bandIndex,
         dtype=np.float32,
     )
@@ -506,6 +558,9 @@ def updateBlendRecords(blendData, catalog, modelPsf, observedPsf, redistributeIm
             useFlux=useFlux,
         )
         sourceRecord.setFootprint(heavy)
+        # Set the fraction of pixels with valid data.
+        coverage = calculateFootprintCoverage(heavy, maskImage)
+        sourceRecord.set("deblend_dataCoverage", coverage)
 
         if updateFluxColumns:
             # Set the flux of the scarlet model
@@ -721,12 +776,12 @@ def multibandDataToScarlet(
 
     # Extract the blend data
     blendData = modelData.blends[blendId]
-    nBands = len(modelData.bands)
+    nBands = len(blendData.bands)
     modelBox = Box((nBands,) + tuple(blendData.extent[::-1]), origin=(0, 0, 0))
     blend = dataToScarlet(blendData, nBands=nBands)
 
     if mExposure is None:
-        psfModels = computePsfImage(observedPsfs, blendData.psfCenter, modelData.bands)
+        psfModels = computePsfImage(observedPsfs, blendData.psfCenter, blendData.bands)
         blend.observation = DummyObservation(
             psfs=psfModels,
             model_psf=modelData.psf[None, :, :],
@@ -743,17 +798,13 @@ def multibandDataToScarlet(
     return blend
 
 
-def dataToScarlet(blendData, nBands=None, bandIndex=None, dtype=np.float32):
+def dataToScarlet(blendData, bandIndex=None, dtype=np.float32):
     """Convert the storage data model into a scarlet lite blend
 
     Parameters
     ----------
     blendData : `ScarletBlendData`
         Persistable data for the entire blend.
-    nBands : `int`
-        The number of bands in the image.
-        If `bandIndex` is `None` then this parameter is ignored and
-        the number of bands is set to 1.
     bandIndex : `int`
         Index of model to extract. If `bandIndex` is `None` then the
         full model is extracted.
@@ -767,6 +818,8 @@ def dataToScarlet(blendData, nBands=None, bandIndex=None, dtype=np.float32):
     """
     if bandIndex is not None:
         nBands = 1
+    else:
+        nBands = len(blendData.bands)
     modelBox = Box((nBands,) + tuple(blendData.extent[::-1]), origin=(0, 0, 0))
     sources = []
     for sourceId, sourceData in blendData.sources.items():
@@ -814,7 +867,7 @@ def dataToScarlet(blendData, nBands=None, bandIndex=None, dtype=np.float32):
     return LiteBlend(sources=sources, observation=None)
 
 
-def scarletLiteToData(blend, psfCenter, xy0):
+def scarletLiteToData(blend, psfCenter, xy0, bands):
     """Convert a scarlet lite blend into a persistable data object
 
     Parameters
@@ -825,6 +878,10 @@ def scarletLiteToData(blend, psfCenter, xy0):
         The center of the PSF.
     xy0 : `tuple` of `int`
         The lower coordinate of the entire blend.
+    bands : `tuple[str]`
+        The bands that were deblended.
+        This ignores bands that could not be deblended because the
+        observed PSF could not be modeled.
 
     Returns
     -------
@@ -863,12 +920,13 @@ def scarletLiteToData(blend, psfCenter, xy0):
         extent=blend.observation.bbox.shape[1:][::-1],
         sources=sources,
         psfCenter=psfCenter,
+        bands=bands,
     )
 
     return blendData
 
 
-def scarletToData(blend, psfCenter, xy0):
+def scarletToData(blend, psfCenter, xy0, bands):
     """Convert a scarlet blend into a persistable data object
 
     Parameters
@@ -879,6 +937,10 @@ def scarletToData(blend, psfCenter, xy0):
         The center of the PSF.
     xy0 : `tuple` of `int`
         The lower coordinate of the entire blend.
+    bands : `tuple[str]`
+        The bands that were deblended.
+        This ignores bands that could not be deblended because the
+        observed PSF could not be modeled.
 
     Returns
     -------
@@ -906,6 +968,7 @@ def scarletToData(blend, psfCenter, xy0):
         extent=tuple(int(x) for x in blend.observation.bbox.shape[1:][::-1]),
         sources=sources,
         psfCenter=psfCenter,
+        bands=bands,
     )
 
     return blendData

--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -160,11 +160,6 @@ def deblend(mExposure, footprint, config, spectrumInit):
     skipped : `list` of `int`
         The indices of any children that failed to initialize
         and were skipped.
-    spectrumInit : `bool`
-        Whether or not all of the sources were initialized by jointly
-        fitting their SED's. This provides a better initialization
-        but created memory issues when a blend is too large or
-        contains too many sources.
     """
     # Extract coordinates from each MultiColorPeak
     bbox = footprint.getBBox()
@@ -268,7 +263,7 @@ def deblend(mExposure, footprint, config, spectrumInit):
     # Store the location of the PSF center for storage
     blend.psfCenter = (psfCenter.x, psfCenter.y)
 
-    return blend, skipped, []
+    return blend, skipped
 
 
 def buildLiteObservation(
@@ -866,7 +861,7 @@ class ScarletDeblendTask(pipeBase.Task):
         self.deblendErrorKey = schema.addField('deblend_error', type="String", size=25,
                                                doc='Name of error if the blend failed')
         self.incompleteDataKey = schema.addField('deblend_incompleteData', type='Flag',
-                                                 doc='True when a bland has at least one band '
+                                                 doc='True when a blend has at least one band '
                                                      'that could not generate a PSF and was '
                                                      'not included in the model.')
         # Deblended source fields
@@ -1061,7 +1056,8 @@ class ScarletDeblendTask(pipeBase.Task):
                 t0 = time.monotonic()
                 # Build the parameter lists with the same ordering
                 if self.config.version == "scarlet":
-                    blend, skippedSources, skippedBands = deblend(mExposure, foot, self.config, spectrumInit)
+                    blend, skippedSources = deblend(mExposure, foot, self.config, spectrumInit)
+                    skippedBands = []
                 elif self.config.version == "lite":
                     blend, skippedSources, skippedBands = deblend_lite(
                         mExposure=mExposure,

--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -33,7 +33,7 @@ from scarlet import lite
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
-from lsst.geom import Point2I, Point2D
+import lsst.geom as geom
 import lsst.afw.geom.ellipses as afwEll
 import lsst.afw.image as afwImage
 import lsst.afw.detection as afwDet
@@ -106,6 +106,36 @@ def isPseudoSource(source, pseudoColumns):
         except KeyError:
             pass
     return isPseudo
+
+
+def computePsfKernelImage(mExposure, psfCenter):
+    """Compute the PSF kernel image and update the multiband exposure
+    if not all of the PSF images could be computed.
+
+    Parameters
+    ----------
+    psfCenter : `tuple` or `Point2I` or `Point2D`
+        The location `(x, y)` used as the center of the PSF.
+
+    Returns
+    -------
+    psfModels : `np.ndarray`
+        The multiband PSF image
+    mExposure : `MultibandExposure`
+        The exposure, updated to only use bands that
+        successfully generated a PSF image.
+    """
+    if not isinstance(psfCenter, geom.Point2D):
+        psfCenter = geom.Point2D(*psfCenter)
+
+    try:
+        psfModels = mExposure.computePsfKernelImage(psfCenter)
+    except IncompleteDataError as e:
+        psfModels = e.partialPsf
+        # Use only the bands that successfully generated a PSF image.
+        mExposure = mExposure[psfModels.filters,]
+
+    return psfModels.array, mExposure
 
 
 def deblend(mExposure, footprint, config, spectrumInit):
@@ -238,7 +268,7 @@ def deblend(mExposure, footprint, config, spectrumInit):
     # Store the location of the PSF center for storage
     blend.psfCenter = (psfCenter.x, psfCenter.y)
 
-    return blend, skipped
+    return blend, skipped, []
 
 
 def buildLiteObservation(
@@ -288,9 +318,7 @@ def buildLiteObservation(
         The observation constructed from the input parameters.
     """
     # Initialize the observed PSFs
-    if not isinstance(psfCenter, Point2D):
-        psfCenter = Point2D(*psfCenter)
-    psfModels = mExposure.computePsfKernelImage(psfCenter)
+    psfModels, mExposure = computePsfKernelImage(mExposure, psfCenter)
 
     # Use the inverse variance as the weights
     if useWeights:
@@ -308,7 +336,7 @@ def buildLiteObservation(
         # Mask out the pixels outside the footprint
         weights *= footprint.spans.asArray()
 
-    return lite.LiteObservation(
+    observation = lite.LiteObservation(
         images=mExposure.image.array,
         variance=mExposure.variance.array,
         weights=weights,
@@ -316,6 +344,10 @@ def buildLiteObservation(
         model_psf=modelPsf[None, :, :],
         convolution_mode=convolutionType,
     )
+
+    # Store the bands used to create the observation
+    observation.bands = mExposure.filters
+    return observation
 
 
 def deblend_lite(mExposure, modelPsf, footprint, config, spectrumInit, wavelets=None):
@@ -330,6 +362,17 @@ def deblend_lite(mExposure, modelPsf, footprint, config, spectrumInit, wavelets=
         - The footprint of the parent to deblend
     config : `ScarletDeblendConfig`
         - Configuration of the deblending task
+
+    Returns
+    -------
+    blend : `scarlet.lite.Blend`
+        The blend this is to be deblended
+    skippedSources : `list[int]`
+        Indices of sources that were skipped due to no flux.
+        This usually means that a source was a spurrious detection in one
+        band that should not have been included in the merged catalog.
+    skippedBands : `list[str]`
+        Bands that were skipped because a PSF could not be generated for them.
     """
     # Extract coordinates from each MultiColorPeak
     bbox = footprint.getBBox()
@@ -406,7 +449,7 @@ def deblend_lite(mExposure, modelPsf, footprint, config, spectrumInit, wavelets=
         blend.fit_spectra()
 
     # Set the sources that could not be initialized and were skipped
-    skipped = [src for src in sources if src.is_null]
+    skippedSources = [src for src in sources if src.is_null]
 
     blend.fit(
         max_iter=config.maxIter,
@@ -418,7 +461,10 @@ def deblend_lite(mExposure, modelPsf, footprint, config, spectrumInit, wavelets=
     # Store the location of the PSF center for storage
     blend.psfCenter = (psfCenter.x, psfCenter.y)
 
-    return blend, skipped
+    # Calculate the bands that were skipped
+    skippedBands = [band for band in mExposure.filters if band not in observation.bands]
+
+    return blend, skippedSources, skippedBands
 
 
 @dataclass
@@ -819,6 +865,10 @@ class ScarletDeblendTask(pipeBase.Task):
                                                 doc="Deblending failed on source")
         self.deblendErrorKey = schema.addField('deblend_error', type="String", size=25,
                                                doc='Name of error if the blend failed')
+        self.incompleteDataKey = schema.addField('deblend_incompleteData', type='Flag',
+                                                 doc='True when a bland has at least one band '
+                                                     'that could not generate a PSF and was '
+                                                     'not included in the model.')
         # Deblended source fields
         self.peakCenter = afwTable.Point2IKey.addFields(schema, name="deblend_peak_center",
                                                         doc="Center used to apply constraints in scarlet",
@@ -855,6 +905,9 @@ class ScarletDeblendTask(pipeBase.Task):
                                                   "this column is set to zero.")
         self.psfKey = schema.addField('deblend_deblendedAsPsf', type='Flag',
                                       doc='Deblender thought this source looked like a PSF')
+        self.coverageKey = schema.addField('deblend_dataCoverage', type=np.float32,
+                                           doc='Fraction of pixels with data. '
+                                               'In other words, 1 - fraction of pixels with NO_DATA set.')
         # Blendedness/classification metrics
         self.maxOverlapKey = schema.addField("deblend_maxOverlap", type=np.float32,
                                              doc="Maximum overlap with all of the other neighbors flux "
@@ -946,7 +999,6 @@ class ScarletDeblendTask(pipeBase.Task):
             maxId = np.max(catalog["id"])
             idFactory.notify(maxId)
 
-        filters = mExposure.filters
         self.log.info("Deblending %d sources in %d exposure bands", len(catalog), len(mExposure))
         periodicLog = PeriodicLogger(self.log)
 
@@ -965,7 +1017,7 @@ class ScarletDeblendTask(pipeBase.Task):
 
         # Initialize the persistable data model
         modelPsf = lite.integrated_circular_gaussian(sigma=self.config.modelPsfSigma)
-        dataModel = ScarletModelData(filters, modelPsf)
+        dataModel = ScarletModelData(modelPsf)
 
         nParents = len(catalog)
         nDeblendedParents = 0
@@ -1009,9 +1061,9 @@ class ScarletDeblendTask(pipeBase.Task):
                 t0 = time.monotonic()
                 # Build the parameter lists with the same ordering
                 if self.config.version == "scarlet":
-                    blend, skipped = deblend(mExposure, foot, self.config, spectrumInit)
+                    blend, skippedSources, skippedBands = deblend(mExposure, foot, self.config, spectrumInit)
                 elif self.config.version == "lite":
-                    blend, skipped = deblend_lite(
+                    blend, skippedSources, skippedBands = deblend_lite(
                         mExposure=mExposure,
                         modelPsf=modelPsf,
                         footprint=foot,
@@ -1028,12 +1080,13 @@ class ScarletDeblendTask(pipeBase.Task):
                 else:
                     nComponents = 0
                 nChild = len(blend.sources)
+                parent.set(self.incompleteDataKey, len(skippedBands) > 0)
             # Catch all errors and filter out the ones that we know about
             except Exception as e:
                 blendError = type(e).__name__
                 if isinstance(e, ScarletGradientError):
                     parent.set(self.iterKey, e.iterations)
-                elif not isinstance(e, IncompleteDataError):
+                else:
                     blendError = "UnknownError"
                     if self.config.catchFailures:
                         # Make it easy to find UnknownErrors in the log file
@@ -1073,7 +1126,7 @@ class ScarletDeblendTask(pipeBase.Task):
             for k, scarletSource in enumerate(blend.sources):
                 # Skip any sources with no flux or that scarlet skipped because
                 # it could not initialize
-                if k in skipped or (self.config.version == "lite" and scarletSource.is_null):
+                if k in skippedSources or (self.config.version == "lite" and scarletSource.is_null):
                     # No need to propagate anything
                     continue
                 parent.set(self.deblendSkippedKey, False)
@@ -1091,9 +1144,9 @@ class ScarletDeblendTask(pipeBase.Task):
 
             # Store the blend information so that it can be persisted
             if self.config.version == "lite":
-                blendData = scarletLiteToData(blend, blend.psfCenter, bbox.getMin())
+                blendData = scarletLiteToData(blend, blend.psfCenter, bbox.getMin(), blend.observation.bands)
             else:
-                blendData = scarletToData(blend, blend.psfCenter, bbox.getMin())
+                blendData = scarletToData(blend, blend.psfCenter, bbox.getMin(), mExposure.filters)
             dataModel.blends[parent.getId()] = blendData
 
             # Log a message if it has been a while since the last log.
@@ -1367,11 +1420,14 @@ class ScarletDeblendTask(pipeBase.Task):
         # deblenders and across observations, where the peak
         # position is unlikely to change unless enough time passes
         # for a source to move on the sky.
-        src.set(self.peakCenter, Point2I(peak["i_x"], peak["i_y"]))
+        src.set(self.peakCenter, geom.Point2I(peak["i_x"], peak["i_y"]))
         src.set(self.peakIdKey, peak["id"])
 
         # Store the number of components for the source
         src.set(self.nComponentsKey, len(scarletSource.components))
+
+        # Flag sources missing one or more bands
+        src.set(self.incompleteDataKey, parent.get(self.incompleteDataKey))
 
         # Propagate columns from the parent to the child
         for parentColumn, childColumn in self.config.columnInheritance.items():

--- a/tests/test_deblend.py
+++ b/tests/test_deblend.py
@@ -104,7 +104,6 @@ class TestDeblend(lsst.utils.tests.TestCase):
         src.setFootprint(denseFoot)
 
         # Run the deblender
-        print("RUNNING!")
         catalog, modelData = deblendTask.run(coadds, catalog)
 
         # Attach the footprints in each band and compare to the full

--- a/tests/test_deblend.py
+++ b/tests/test_deblend.py
@@ -104,6 +104,7 @@ class TestDeblend(lsst.utils.tests.TestCase):
         src.setFootprint(denseFoot)
 
         # Run the deblender
+        print("RUNNING!")
         catalog, modelData = deblendTask.run(coadds, catalog)
 
         # Attach the footprints in each band and compare to the full
@@ -125,6 +126,7 @@ class TestDeblend(lsst.utils.tests.TestCase):
                     catalog,
                     band=band,
                     psfModel=psfModel,
+                    maskImage=coadd.mask,
                     redistributeImage=redistributeImage,
                     removeScarletData=False,
                 )
@@ -170,7 +172,6 @@ class TestDeblend(lsst.utils.tests.TestCase):
                     blendData = modelData.blends[child["parent"]]
                     blend = dataToScarlet(
                         blendData=blendData,
-                        nBands=1,
                         bandIndex=bandIndex,
                     )
                     # We need to set an observation in order to convolve


### PR DESCRIPTION
Previously any footprints that could not construct a PSF in all bands were skipped. As part of HSC PDR4, because there are patches with only partial coverage of narrow bands (for example), we want to allow the deblender to proceed.

This ticket implements deblending with only partial PSF coverage, and also adds new columns to the catalog to keep track of the coverage per band.