### PR TITLE
DM-41008-v24: Update deblend_coverage for all parents

### DIFF
--- a/python/lsst/meas/extensions/scarlet/io.py
+++ b/python/lsst/meas/extensions/scarlet/io.py
@@ -411,6 +411,15 @@ class ScarletModelData:
                 # no models for its sources.
                 continue
 
+            parent = catalog.find(parentId)
+            if updateFluxColumns and redistributeImage is not None:
+                # Update the data coverage
+                # (1 - # of NO_DATA pixels/# of pixels)
+                parentRecord["deblend_dataCoverage"] = calculateFootprintCoverage(
+                    parent.getFootprint(),
+                    maskImage
+                )
+
             if band not in blendModel.bands:
                 parent = catalog.find(parentId)
                 peaks = parent.getFootprint().peaks

--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -139,7 +139,7 @@ def computePsfKernelImage(mExposure, psfCenter):
         psfModels = e.partialPsf
         # Use only the bands that successfully generated a PSF image.
         bands = psfModels.filters
-        mExposure = mExposure[bands,]
+        mExposure = mExposure[bands, ]
         if len(bands) == 1:
             # Only a single band generated a PSF, so the MultibandExposure
             # became a single band ExposureF.


### PR DESCRIPTION
Needs to be merged after DM-40957-v24. Base will change to v24.0.x after rebase.