### PR TITLE
DM-43176: Flag sources with no flux after re-distribution.

### DIFF
--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -783,6 +783,8 @@ class ScarletDeblendTask(pipeBase.Task):
         self.coverageKey = schema.addField('deblend_dataCoverage', type=np.float32,
                                            doc='Fraction of pixels with data. '
                                                'In other words, 1 - fraction of pixels with NO_DATA set.')
+        self.zeroFluxKey = schema.addField("deblend_zeroFlux", type="Flag",
+                                           doc="Source has zero flux.")
         # Blendedness/classification metrics
         self.maxOverlapKey = schema.addField("deblend_maxOverlap", type=np.float32,
                                              doc="Maximum overlap with all of the other neighbors flux "


### PR DESCRIPTION
Sometimes errors in the pipelines, like incorrect PSF modeling, can cause sources with valid scarlet models to have no flux after flux re-distribution when the footprints are being reconstructed. This commit adds a `deblend_zeroFlux` column to identify sources that have zero flux in a given band for follow-up.