### PR TITLE
DM-43843: Fix bug in incomlete data error checking

### DIFF
--- a/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
+++ b/python/lsst/meas/extensions/scarlet/scarletDeblendTask.py
@@ -40,6 +40,7 @@ import lsst.afw.detection as afwDet
 import lsst.afw.table as afwTable
 from lsst.utils.logging import PeriodicLogger
 from lsst.utils.timer import timeMethod
+from lsst.afw.image.exposure._multiband import IncompleteDataError
 
 from .source import bboxToScarletBox
 from .io import ScarletModelData, scarletToData, scarletLiteToData
@@ -56,12 +57,6 @@ proxminLogger.setLevel(logging.ERROR)
 __all__ = ["deblend", "deblend_lite", "ScarletDeblendConfig", "ScarletDeblendTask"]
 
 logger = logging.getLogger(__name__)
-
-
-class IncompleteDataError(Exception):
-    """The PSF could not be computed due to incomplete data
-    """
-    pass
 
 
 class ScarletGradientError(Exception):


### PR DESCRIPTION
In the backport for DM-40451 I missed importing IncompleteDataError from lsst.afw.image, where it resides now, and instead tried to catch an error in PSF image generation with a local version of IncompleteDataError in meas_extensions_scarlet
(the original place where the PSF image was generated).